### PR TITLE
Fix error when commit body blank.

### DIFF
--- a/git-verify_committers-roush_dev.py
+++ b/git-verify_committers-roush_dev.py
@@ -58,7 +58,7 @@ member_list = [x['login'] for x in json.loads(content)]
 GIT_USER = os.environ.get('GIT_USER')
 GIT_PULL_URL = os.environ.get('GIT_PULL_URL')
 GIT_COMMENT_URL = os.environ.get('GIT_COMMENT_URL')
-GIT_COMMIT_MSG_BODY = os.environ.get('GIT_COMMIT_MSG_BODY')
+GIT_COMMIT_MSG_BODY = os.environ.get('GIT_COMMIT_MSG_BODY', '')
 
 if GIT_USER is None:
     print "Environment variable GIT_USER not found, aborting."


### PR DESCRIPTION
When commit message blank TypeError thrown because GIT_COMMIT_MSG_BODY set to None.
- /home/jenkins/jenkins-build/git-verify_committers-roush_dev.py
  Traceback (most recent call last):
  File "/home/jenkins/jenkins-build/git-verify_committers-roush_dev.py", line 78, in <module>
    rallyid = _check_for_rallyid(GIT_COMMIT_MSG_BODY)
  File "/home/jenkins/jenkins-build/git-verify_committers-roush_dev.py", line 25, in _check_for_rallyid
    match = re.match(pattern, msg)
  File "/usr/lib/python2.6/re.py", line 137, in match
    return _compile(pattern, flags).match(string)
  TypeError: expected string or buffer
