### PR TITLE
Cope with ceph submodule repo name not being checkout dir.

### DIFF
--- a/gate-upstream-repo-commits-parent
+++ b/gate-upstream-repo-commits-parent
@@ -30,7 +30,7 @@ for branch in $branches; do
     declare -a updated
 
     # get list of submodules to check
-    repolist=$(awk '/url/ && $3 !~/'"${SKIP_REGEX}"'/ {print $3}' .gitmodules)
+    repolist=$(awk '/path/{submodule=$3}; /url/ && $3 !~/'"${SKIP_REGEX}"'/ {print submodule}' .gitmodules)
 
     # check each and fire off downstream job if repo has changed
     for repo in ${repolist}; do


### PR DESCRIPTION
The upstream ceph cookbooks url is github.com/ceph/ceph-cookbooks,
but it is checked out as a submodule as cookbooks/ceph. This leads to
the following error when looping through and checking for updates:
- for repo in '${repolist}'
  ++ echo ceph-cookbooks
  ++ cut -d. -f1
- submodule=ceph-cookbooks
- git submodule init
- git submodule update cookbooks/ceph-cookbooks
  error: pathspec 'cookbooks/ceph-cookbooks' did not match any file(s)
  known to git.
  Did you forget to 'git add'?
- pushd cookbooks/ceph-cookbooks
  /home/jenkins/jenkins-build/gate-upstream-repo-commits-parent: line 45:
  pushd: cookbooks/ceph-cookbooks: No such file or directory
  Build step 'Execute shell' marked build as failure
  Notifying upstream projects of job completion
  Finished: FAILURE

The fix is to use the gitmodule path rather than the url to determine where
the checkout is. The slight complication is that the url must still be
used for checking exclusions as the path doesn't contain enough data.
