### PR TITLE
Clone repository with specific branch

### DIFF
--- a/multi-gate/gate-GIT-Pull-Request
+++ b/multi-gate/gate-GIT-Pull-Request
@@ -12,12 +12,11 @@ rm -f chef-cookbooks.tgz
 rm -f patch.diff
 
 if [[ ! -d ${TARGET_DIR} ]]; then
-  git clone ${GIT_MASTER_URL} ${TARGET_DIR}
+  git clone -b ${GIT_BRANCH} ${GIT_MASTER_URL} ${TARGET_DIR}
 fi
 
 # setup the git repo
 pushd ${TARGET_DIR}
-git checkout ${GIT_BRANCH}
 git clean -ffdx
 git pull origin ${GIT_BRANCH}
 git submodule init


### PR DESCRIPTION
Ensure that when we clone the repos in question, we are getting a ref to the
branch being tested to avoid these errors:
- git checkout v4.2.1rc
  error: pathspec 'v4.2.1rc' did not match any file(s) known to git.
